### PR TITLE
Add prompt_browser app and extractor --jsonl; document render env

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Python scripts I am building to help with my ai addiction
 | --- | --- |
 | `loras/` | Trained LoRA `.safetensors` weights, organized into a subfolder per base model. |
 | `lora_utilities/` | Python utilities for inspecting LoRAs and extracting metadata from generated images (see below), plus the exported CSVs. |
+| `prompt_browser/` | PostgreSQL-backed app to browse extracted prompts and re-submit them to the ComfyUI API to generate. See `prompt_browser/README.md`. |
 | `OneTrainer/trainer_presets/` | [OneTrainer](https://github.com/Nerogar/OneTrainer) LoRA training config presets (`.json`). |
 | `fluxgym_mods/` | Modifications for [fluxgym](https://github.com/cocktailpeanut/fluxgym) (e.g. `models.yaml`). |
 | `renders/` | Sample ComfyUI-generated PNGs (with embedded generation metadata). |

--- a/lora_utilities/extract_render_metadata.py
+++ b/lora_utilities/extract_render_metadata.py
@@ -638,6 +638,9 @@ def process_file(path, root):
     row["lora_count"] = len(loras)
     row["image_type"] = classify_image_type(pos, row["loras"])
     row.update(extract_dims_and_sampling(graph))
+    # Keep the raw ComfyUI graph for downstream replay (DB import / regeneration).
+    # Not a CSV column -- the underscore key is ignored by the CSV writers.
+    row["_graph"] = graph
     return row, True
 
 
@@ -656,6 +659,10 @@ def main():
                     help="Output CSV path (default: render_metadata.csv)")
     ap.add_argument("--limit", type=int, default=0,
                     help="Process at most N files (0 = all). Useful for testing.")
+    ap.add_argument("--jsonl", default=None,
+                    help="Also write a JSON Lines file: one record per PNG with all "
+                         "fields PLUS the raw ComfyUI workflow graph under 'workflow'. "
+                         "This is the import source for the prompt_browser database.")
     ap.add_argument("--no-dedup", action="store_true",
                     help="Skip writing the deduplicated *_unique.csv.")
     ap.add_argument("--dedup-only", action="store_true",
@@ -711,26 +718,37 @@ def main():
         return
 
     total = with_meta = without = 0
-    collected = []  # kept for the dedup phase
-    with open(args.output, "w", newline="", encoding="utf-8-sig") as fh:
-        writer = csv.DictWriter(fh, fieldnames=FIELDS)
-        writer.writeheader()
-        for path in iter_pngs(args.input):
-            row, ok = process_file(path, args.input)
-            writer.writerow(row)
-            if not args.no_dedup:
-                collected.append(row)
-            total += 1
-            with_meta += 1 if ok else 0
-            without += 0 if ok else 1
-            if total % 500 == 0:
-                print("  processed %d files (%d with metadata)..." % (total, with_meta))
-            if args.limit and total >= args.limit:
-                break
+    collected = []  # kept for the dedup phase (graph stripped to bound memory)
+    jsonl_fh = open(args.jsonl, "w", encoding="utf-8") if args.jsonl else None
+    try:
+        with open(args.output, "w", newline="", encoding="utf-8-sig") as fh:
+            writer = csv.DictWriter(fh, fieldnames=FIELDS, extrasaction="ignore")
+            writer.writeheader()
+            for path in iter_pngs(args.input):
+                row, ok = process_file(path, args.input)
+                writer.writerow(row)  # extrasaction="ignore" drops _graph
+                if jsonl_fh is not None:
+                    record = {f: row.get(f, "") for f in FIELDS}
+                    record["workflow"] = row.get("_graph")
+                    jsonl_fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+                if not args.no_dedup:
+                    collected.append({f: row.get(f, "") for f in FIELDS})  # no graph
+                total += 1
+                with_meta += 1 if ok else 0
+                without += 0 if ok else 1
+                if total % 500 == 0:
+                    print("  processed %d files (%d with metadata)..." % (total, with_meta))
+                if args.limit and total >= args.limit:
+                    break
+    finally:
+        if jsonl_fh is not None:
+            jsonl_fh.close()
 
     print("\nDone. %d PNGs scanned -> %s" % (total, args.output))
     print("  with generation metadata: %d" % with_meta)
     print("  without metadata:         %d" % without)
+    if args.jsonl:
+        print("  workflow graphs -> %s" % args.jsonl)
 
     if not args.no_dedup:
         n_unique, collapsed = write_unique_csv(collected, uniq_out)

--- a/prompt_browser/.env.example
+++ b/prompt_browser/.env.example
@@ -1,0 +1,7 @@
+# Copy to .env and adjust. Loaded by build_db.py and app.py via python-dotenv.
+
+# PostgreSQL connection (libpq URL).
+DATABASE_URL=postgresql://prompts:prompts@localhost:5432/prompts
+
+# ComfyUI server (must be running with the API enabled; default port 8188).
+COMFYUI_URL=http://127.0.0.1:8188

--- a/prompt_browser/README.md
+++ b/prompt_browser/README.md
@@ -1,0 +1,79 @@
+# prompt_browser
+
+Browse the prompts/metadata extracted from your renders (stored in PostgreSQL),
+pick one, optionally tweak the seed or prompt, and re-submit the original
+ComfyUI workflow to generate a new image.
+
+```
+extract_render_metadata.py --jsonl   ->   build_db.py   ->   PostgreSQL
+                                                                  |
+                                                          app.py (Streamlit)
+                                                                  |
+                                                       ComfyUI  /prompt  API
+```
+
+The key idea: each render's **raw ComfyUI workflow graph** is stored alongside
+its metadata, so "generate" just replays that exact graph (optionally with a new
+seed/prompt) — no per-workflow templates to maintain, and any past image is
+reproducible.
+
+## Prerequisites
+
+- **PostgreSQL** running. Native install, or quick container:
+  ```bash
+  docker run -d --name prompts-pg -p 5432:5432 \
+    -e POSTGRES_USER=prompts -e POSTGRES_PASSWORD=prompts -e POSTGRES_DB=prompts \
+    postgres:16
+  ```
+- **ComfyUI** running with its API (default `http://127.0.0.1:8188`).
+- The **`render` conda environment** (this project's env):
+  ```bash
+  conda activate render
+  pip install -r requirements.txt
+  ```
+
+## Setup
+
+> All commands below assume `conda activate render` is active.
+
+1. Copy config and edit:
+   ```bash
+   cp .env.example .env       # set DATABASE_URL and COMFYUI_URL
+   ```
+2. Extract metadata **with workflow graphs** (note `--jsonl`):
+   ```bash
+   python ../lora_utilities/extract_render_metadata.py \
+       -i "E:/DATA/renders" -o renders.csv --jsonl renders.jsonl --no-dedup
+   ```
+3. Load into PostgreSQL (creates the schema on first run, upserts on re-runs):
+   ```bash
+   python build_db.py renders.jsonl
+   ```
+4. Launch the UI:
+   ```bash
+   streamlit run app.py
+   ```
+
+To import another batch later (e.g. the next 100k images), repeat steps 2–3 with
+the new render directory; rows are upserted by `file_path`, so nothing duplicates.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `schema.sql` | PostgreSQL schema (generations + loras + generation_loras, trigram prompt index). |
+| `db.py` | Connection helper (reads `DATABASE_URL`). |
+| `build_db.py` | Loads the extractor JSONL into PostgreSQL. |
+| `comfy_client.py` | Minimal ComfyUI API client (queue / progress / fetch images). |
+| `graph_patch.py` | Sets/randomizes seed and best-effort overrides the positive prompt in a stored graph. |
+| `app.py` | Streamlit browser + generate UI. |
+
+## Notes & limits
+
+- **Assets must exist in ComfyUI.** A replayed graph references model/lora
+  *filenames*; those must be installed where ComfyUI looks (`models/loras`, etc.).
+  Generation fails with a validation error otherwise.
+- **Prompt editing is best-effort.** Workflows that build the prompt from a
+  `Text Concatenate` chain (e.g. the multiperson graphs) can't be safely edited;
+  the app warns and replays the original prompt. Seed override always works.
+- Single-user/local by design — no auth, no queue. ComfyUI serializes jobs.

--- a/prompt_browser/app.py
+++ b/prompt_browser/app.py
@@ -1,0 +1,154 @@
+"""
+prompt_browser -- Streamlit front end.
+
+Browse/filter generations from PostgreSQL, pick one, tweak seed/prompt, and
+re-submit the stored ComfyUI workflow to generate.
+
+Run:  streamlit run app.py
+"""
+import os
+
+import streamlit as st
+from dotenv import load_dotenv
+
+import db
+from comfy_client import ComfyClient
+import graph_patch
+
+load_dotenv()
+COMFYUI_URL = os.environ.get("COMFYUI_URL", "http://127.0.0.1:8188")
+
+st.set_page_config(page_title="Prompt Browser", layout="wide")
+
+
+@st.cache_resource
+def get_conn():
+    return db.connect()
+
+
+def q(sql, params=None, one=False):
+    conn = get_conn()
+    with conn.cursor() as cur:
+        cur.execute(sql, params or ())
+        cols = [c[0] for c in cur.description] if cur.description else []
+        rows = cur.fetchall()
+    conn.commit()
+    dicts = [dict(zip(cols, r)) for r in rows]
+    return (dicts[0] if dicts else None) if one else dicts
+
+
+@st.cache_data(ttl=60)
+def distinct(col):
+    return [r[col] for r in q(
+        "SELECT DISTINCT %s AS %s FROM generations WHERE %s IS NOT NULL ORDER BY 1"
+        % (col, col, col))]
+
+
+@st.cache_data(ttl=60)
+def lora_names():
+    return [r["name"] for r in q("SELECT name FROM loras ORDER BY name")]
+
+
+# --------------------------------------------------------------------------- #
+# Sidebar filters
+# --------------------------------------------------------------------------- #
+st.sidebar.header("Filters")
+f_family = st.sidebar.multiselect("Model family", distinct("model_family"))
+f_type = st.sidebar.multiselect("Gen type", distinct("gen_type"))
+f_image = st.sidebar.multiselect("Image type", distinct("image_type"))
+f_lora = st.sidebar.selectbox("Uses lora", ["(any)"] + lora_names())
+f_text = st.sidebar.text_input("Prompt contains")
+limit = st.sidebar.slider("Max results", 10, 500, 100, step=10)
+
+where, params = [], []
+if f_family:
+    where.append("model_family = ANY(%s)"); params.append(f_family)
+if f_type:
+    where.append("gen_type = ANY(%s)"); params.append(f_type)
+if f_image:
+    where.append("image_type = ANY(%s)"); params.append(f_image)
+if f_text:
+    where.append("positive_prompt ILIKE %s"); params.append("%" + f_text + "%")
+if f_lora != "(any)":
+    where.append("g.id IN (SELECT gl.generation_id FROM generation_loras gl "
+                 "JOIN loras l ON l.id = gl.lora_id WHERE l.name = %s)")
+    params.append(f_lora)
+
+clause = ("WHERE " + " AND ".join(where)) if where else ""
+rows = q(
+    "SELECT g.id, model_family, gen_type, image_type, seed, width, height, "
+    "lora_count, positive_prompt FROM generations g %s ORDER BY g.id DESC LIMIT %s"
+    % (clause, "%s"), params + [limit])
+
+st.title("🎨 Prompt Browser")
+st.caption("%d result(s) — ComfyUI: %s" % (len(rows), COMFYUI_URL))
+
+if not rows:
+    st.info("No matches. Loosen the filters, or run build_db.py to import data.")
+    st.stop()
+
+# Compact table
+st.dataframe(
+    [{"id": r["id"], "family": r["model_family"], "type": r["gen_type"],
+      "rating": r["image_type"], "loras": r["lora_count"],
+      "prompt": (r["positive_prompt"] or "")[:120]} for r in rows],
+    use_container_width=True, hide_index=True)
+
+ids = [r["id"] for r in rows]
+sel_id = st.selectbox("Select a generation id", ids)
+gen = q("SELECT * FROM generations WHERE id=%s", (sel_id,), one=True)
+gen_loras = q(
+    "SELECT l.name, gl.strength FROM generation_loras gl "
+    "JOIN loras l ON l.id=gl.lora_id WHERE gl.generation_id=%s ORDER BY l.name",
+    (sel_id,))
+
+# --------------------------------------------------------------------------- #
+# Detail + generate
+# --------------------------------------------------------------------------- #
+left, right = st.columns([3, 2])
+with left:
+    st.subheader("Prompt")
+    new_prompt = st.text_area("Positive prompt", gen["positive_prompt"] or "", height=160)
+    if gen["negative_prompt"]:
+        st.text_area("Negative prompt (read-only)", gen["negative_prompt"], height=80, disabled=True)
+    st.write("**Loras:** " + (", ".join("%s@%s" % (l["name"], l["strength"]) for l in gen_loras) or "none"))
+
+with right:
+    st.subheader("Settings")
+    st.write({k: gen[k] for k in ("model_family", "model_file", "gen_type",
+                                  "image_type", "width", "height", "steps",
+                                  "sampler", "scheduler", "guidance", "denoise")})
+    randomize = st.checkbox("Randomize seed", value=True)
+    seed_in = st.text_input("Seed (used if not randomizing)", str(gen["seed"] or 0))
+    override_prompt = st.checkbox("Use my edited prompt", value=False,
+                                  help="Off = replay the original prompt exactly.")
+
+if st.button("🚀 Generate", type="primary", use_container_width=True):
+    if not gen.get("workflow"):
+        st.error("This generation has no stored workflow graph; cannot replay.")
+        st.stop()
+    graph, info = graph_patch.prepare(
+        gen["workflow"],
+        new_seed=None if randomize else seed_in,
+        randomize=randomize,
+        positive_prompt=new_prompt if override_prompt else None,
+    )
+    if override_prompt and info["prompt_set"] is False:
+        st.warning("Couldn't locate an editable prompt node (e.g. a composed "
+                   "multi-prompt workflow); generating with the original prompt.")
+    st.caption("Seed: %s" % info["seed"])
+    client = ComfyClient(COMFYUI_URL)
+    bar = st.progress(0.0, text="Queued…")
+    try:
+        def on_progress(v, m):
+            bar.progress(min(v / m, 1.0) if m else 0.0, text="Sampling %d/%d" % (v, m))
+        pid = client.queue(graph)
+        client.wait(pid, on_progress)
+        imgs = client.images(pid)
+        bar.progress(1.0, text="Done")
+        if not imgs:
+            st.warning("Finished but no images returned.")
+        for name, data in imgs:
+            st.image(data, caption=name, use_container_width=True)
+    except Exception as e:
+        st.error("Generation failed: %s" % e)

--- a/prompt_browser/build_db.py
+++ b/prompt_browser/build_db.py
@@ -1,0 +1,169 @@
+"""
+build_db.py -- load the extractor's JSONL into PostgreSQL.
+
+1. Generate the JSONL with the workflow graphs:
+     python ../lora_utilities/extract_render_metadata.py \
+         -i "E:/DATA/renders" -o renders.csv --jsonl renders.jsonl --no-dedup
+2. Load it:
+     python build_db.py renders.jsonl
+
+Re-running is safe: rows are upserted by file_path, so you can append new
+batches (e.g. the next 100k images) without duplicating.
+"""
+import os
+import sys
+import json
+import argparse
+
+import psycopg2
+from psycopg2.extras import execute_batch
+
+from db import connect
+
+SCHEMA_PATH = os.path.join(os.path.dirname(__file__), "schema.sql")
+
+
+def _int(v):
+    try:
+        return int(float(v)) if v not in ("", None) else None
+    except (ValueError, TypeError):
+        return None
+
+
+def _real(v):
+    try:
+        return float(v) if v not in ("", None) else None
+    except (ValueError, TypeError):
+        return None
+
+
+def _seed(v):
+    # seeds are big integers; keep as string for NUMERIC, None if blank/non-numeric
+    if v in ("", None):
+        return None
+    s = str(v).strip()
+    return s if s.lstrip("-").isdigit() else None
+
+
+def parse_loras(loras_str):
+    """'a.safetensors@1; b\\c.safetensors@0.8' -> [('a.safetensors', 1.0), ...]"""
+    out = []
+    for chunk in (loras_str or "").split(";"):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        name, _, strength = chunk.rpartition("@")
+        if not name:                      # no '@' -> whole chunk is the name
+            name, strength = chunk, ""
+        out.append((name.strip(), _real(strength)))
+    return out
+
+
+def ensure_schema(cur):
+    with open(SCHEMA_PATH, encoding="utf-8") as f:
+        cur.execute(f.read())
+
+
+UPSERT_GEN = """
+INSERT INTO generations
+    (file_path, folder, filename, model_family, model_file, gen_type, image_type,
+     positive_prompt, negative_prompt, width, height, steps, sampler, scheduler,
+     guidance, seed, denoise, lora_count, workflow)
+VALUES (%(file_path)s, %(folder)s, %(filename)s, %(model_family)s, %(model_file)s,
+        %(gen_type)s, %(image_type)s, %(positive_prompt)s, %(negative_prompt)s,
+        %(width)s, %(height)s, %(steps)s, %(sampler)s, %(scheduler)s, %(guidance)s,
+        %(seed)s, %(denoise)s, %(lora_count)s, %(workflow)s)
+ON CONFLICT (file_path) DO UPDATE SET
+    folder=EXCLUDED.folder, filename=EXCLUDED.filename,
+    model_family=EXCLUDED.model_family, model_file=EXCLUDED.model_file,
+    gen_type=EXCLUDED.gen_type, image_type=EXCLUDED.image_type,
+    positive_prompt=EXCLUDED.positive_prompt, negative_prompt=EXCLUDED.negative_prompt,
+    width=EXCLUDED.width, height=EXCLUDED.height, steps=EXCLUDED.steps,
+    sampler=EXCLUDED.sampler, scheduler=EXCLUDED.scheduler, guidance=EXCLUDED.guidance,
+    seed=EXCLUDED.seed, denoise=EXCLUDED.denoise, lora_count=EXCLUDED.lora_count,
+    workflow=EXCLUDED.workflow
+RETURNING id;
+"""
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Load extractor JSONL into PostgreSQL.")
+    ap.add_argument("jsonl", help="Path to the JSONL produced by extract_render_metadata.py --jsonl")
+    ap.add_argument("--batch", type=int, default=500, help="Commit every N records.")
+    args = ap.parse_args()
+
+    if not os.path.isfile(args.jsonl):
+        raise SystemExit("JSONL not found: %s" % args.jsonl)
+
+    conn = connect()
+    conn.autocommit = False
+    cur = conn.cursor()
+    ensure_schema(cur)
+    conn.commit()
+
+    lora_cache = {}  # name -> id
+
+    def get_lora_id(name):
+        if name in lora_cache:
+            return lora_cache[name]
+        cur.execute(
+            "INSERT INTO loras (name) VALUES (%s) ON CONFLICT (name) DO UPDATE "
+            "SET name=EXCLUDED.name RETURNING id", (name,))
+        lid = cur.fetchone()[0]
+        lora_cache[name] = lid
+        return lid
+
+    total = skipped = 0
+    with open(args.jsonl, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            rec = json.loads(line)
+            if rec.get("gen_type") == "no-metadata" or not rec.get("workflow"):
+                skipped += 1
+                continue
+            params = {
+                "file_path": rec.get("file_path"),
+                "folder": rec.get("folder"),
+                "filename": rec.get("filename"),
+                "model_family": rec.get("model_family"),
+                "model_file": rec.get("model_file"),
+                "gen_type": rec.get("gen_type"),
+                "image_type": rec.get("image_type"),
+                "positive_prompt": rec.get("positive_prompt"),
+                "negative_prompt": rec.get("negative_prompt"),
+                "width": _int(rec.get("width")),
+                "height": _int(rec.get("height")),
+                "steps": _int(rec.get("steps")),
+                "sampler": rec.get("sampler") or None,
+                "scheduler": rec.get("scheduler") or None,
+                "guidance": _real(rec.get("guidance")),
+                "seed": _seed(rec.get("seed")),
+                "denoise": _real(rec.get("denoise")),
+                "lora_count": _int(rec.get("lora_count")),
+                "workflow": json.dumps(rec.get("workflow")),
+            }
+            cur.execute(UPSERT_GEN, params)
+            gen_id = cur.fetchone()[0]
+            # resync loras for this generation
+            cur.execute("DELETE FROM generation_loras WHERE generation_id=%s", (gen_id,))
+            links = [(gen_id, get_lora_id(n), s) for n, s in parse_loras(rec.get("loras"))]
+            if links:
+                execute_batch(
+                    cur,
+                    "INSERT INTO generation_loras (generation_id, lora_id, strength) "
+                    "VALUES (%s, %s, %s)", links)
+            total += 1
+            if total % args.batch == 0:
+                conn.commit()
+                print("  loaded %d records..." % total)
+
+    conn.commit()
+    cur.close()
+    conn.close()
+    print("\nDone. %d generations loaded/updated, %d skipped (no workflow)." % (total, skipped))
+
+
+if __name__ == "__main__":
+    main()

--- a/prompt_browser/comfy_client.py
+++ b/prompt_browser/comfy_client.py
@@ -1,0 +1,63 @@
+"""Minimal ComfyUI API client: submit a workflow graph, wait, fetch images."""
+import json
+import uuid
+import urllib.parse
+
+import requests
+from websocket import create_connection
+
+
+class ComfyClient:
+    def __init__(self, base_url="http://127.0.0.1:8188"):
+        self.base = base_url.rstrip("/")
+        self.ws_base = self.base.replace("https://", "wss://").replace("http://", "ws://")
+        self.client_id = str(uuid.uuid4())
+
+    def queue(self, graph):
+        """POST a workflow (API format) -> prompt_id."""
+        r = requests.post(
+            "%s/prompt" % self.base,
+            json={"prompt": graph, "client_id": self.client_id},
+            timeout=30,
+        )
+        if r.status_code != 200:
+            # ComfyUI returns validation errors in the body -- surface them.
+            raise RuntimeError("ComfyUI rejected the prompt (%d): %s" % (r.status_code, r.text[:1000]))
+        return r.json()["prompt_id"]
+
+    def wait(self, prompt_id, on_progress=None, timeout=600):
+        """Block until the given prompt finishes, streaming progress."""
+        ws = create_connection("%s/ws?clientId=%s" % (self.ws_base, self.client_id), timeout=timeout)
+        try:
+            while True:
+                msg = ws.recv()
+                if isinstance(msg, (bytes, bytearray)):
+                    continue  # binary preview frames
+                data = json.loads(msg)
+                mtype, mdata = data.get("type"), data.get("data", {})
+                if mtype == "progress" and on_progress:
+                    on_progress(mdata.get("value", 0), mdata.get("max", 1))
+                if (mtype == "executing" and mdata.get("node") is None
+                        and mdata.get("prompt_id") == prompt_id):
+                    break  # this prompt is done
+        finally:
+            ws.close()
+
+    def history(self, prompt_id):
+        return requests.get("%s/history/%s" % (self.base, prompt_id), timeout=30).json()
+
+    def images(self, prompt_id):
+        """Return [(filename, bytes), ...] for the finished prompt."""
+        hist = self.history(prompt_id).get(prompt_id, {})
+        out = []
+        for node_out in hist.get("outputs", {}).values():
+            for img in node_out.get("images", []):
+                q = urllib.parse.urlencode(img)
+                data = requests.get("%s/view?%s" % (self.base, q), timeout=60).content
+                out.append((img.get("filename"), data))
+        return out
+
+    def generate(self, graph, on_progress=None):
+        pid = self.queue(graph)
+        self.wait(pid, on_progress)
+        return self.images(pid)

--- a/prompt_browser/db.py
+++ b/prompt_browser/db.py
@@ -1,0 +1,20 @@
+"""Shared PostgreSQL connection helper."""
+import os
+import psycopg2
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def get_dsn():
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        raise SystemExit(
+            "DATABASE_URL is not set. Copy .env.example to .env and set it, "
+            "e.g. postgresql://prompts:prompts@localhost:5432/prompts"
+        )
+    return dsn
+
+
+def connect():
+    return psycopg2.connect(get_dsn())

--- a/prompt_browser/graph_patch.py
+++ b/prompt_browser/graph_patch.py
@@ -1,0 +1,139 @@
+"""
+Patch a stored ComfyUI workflow graph before re-submitting:
+  - set / randomize the seed
+  - (best-effort) override the positive prompt
+
+Reuses the trace helpers in lora_utilities/extract_render_metadata.py so prompt
+location matches how the prompt was originally extracted.
+"""
+import os
+import sys
+import copy
+import random
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lora_utilities"))
+import extract_render_metadata as ext  # noqa: E402
+
+MAX_SEED = 2 ** 63 - 1
+
+
+def set_seed(graph, seed):
+    """Set every literal seed/noise_seed input. Returns the seed used."""
+    for node in graph.values():
+        if not isinstance(node, dict):
+            continue
+        ins = node.get("inputs", {})
+        for key in ("noise_seed", "seed"):
+            if key in ins and not ext.is_link(ins[key]):
+                ins[key] = seed
+    return seed
+
+
+def randomize_seed(graph):
+    return set_seed(graph, random.randint(0, MAX_SEED))
+
+
+def _string_target(graph, ref, depth=0, seen=None):
+    """Find (node_id, input_key) holding the literal positive-prompt string, or
+    None if it can't be set safely (e.g. built by a Text Concatenate node)."""
+    if seen is None:
+        seen = set()
+    if depth > 24 or not ext.is_link(ref):
+        return None
+    nid = str(ref[0])
+    if nid in seen:
+        return None
+    seen.add(nid)
+    node = graph.get(nid)
+    if not isinstance(node, dict):
+        return None
+    ins = node.get("inputs", {})
+    ct = ext.node_ct(node)
+
+    if any(ct == t or ct.startswith(t) for t in ext.TEXT_ENCODE):
+        for key in ("text", "t5xxl", "t5xl", "clip_l", "text_g", "text_l"):
+            if key in ins:
+                v = ins[key]
+                if isinstance(v, str):
+                    return (nid, key)
+                if ext.is_link(v):
+                    r = _literal_target(graph, v, depth + 1, seen)
+                    if r:
+                        return r
+        return None
+
+    # passthrough conditioning node -> follow its conditioning input(s)
+    for k, v in ins.items():
+        if any(s in k.lower() for s in ("conditioning", "positive", "cond")) and ext.is_link(v):
+            r = _string_target(graph, v, depth + 1, seen)
+            if r:
+                return r
+    for k, v in ins.items():
+        if ext.is_link(v):
+            r = _string_target(graph, v, depth + 1, seen)
+            if r:
+                return r
+    return None
+
+
+def _literal_target(graph, ref, depth, seen):
+    """Follow a link to a node whose literal text/string input can be set."""
+    if depth > 24 or not ext.is_link(ref):
+        return None
+    nid = str(ref[0])
+    node = graph.get(nid)
+    if not isinstance(node, dict):
+        return None
+    ct = ext.node_ct(node)
+    if "Concatenate" in ct:
+        return None  # composed from multiple inputs -- don't clobber
+    ins = node.get("inputs", {})
+    for key in ("text", "string", "value", "Text", "String", "text_multiline", "prompt"):
+        if key in ins:
+            v = ins[key]
+            if isinstance(v, str):
+                return (nid, key)
+            if ext.is_link(v):
+                r = _literal_target(graph, v, depth + 1, seen)
+                if r:
+                    return r
+    return None
+
+
+def set_positive_prompt(graph, text):
+    """Best-effort override of the positive prompt. Returns True on success."""
+    _sid, snode = ext.find_output_sampler(graph)
+    if not snode:
+        return False
+    ins = snode.get("inputs", {})
+    ref = None
+    if "positive" in ins and ext.is_link(ins["positive"]):
+        ref = ins["positive"]
+    elif "guider" in ins and ext.is_link(ins["guider"]):
+        g = graph.get(str(ins["guider"][0]), {})
+        gi = g.get("inputs", {}) if isinstance(g, dict) else {}
+        for key in ("conditioning", "positive", "cond"):
+            if key in gi and ext.is_link(gi[key]):
+                ref = gi[key]
+                break
+    if not ref:
+        return False
+    target = _string_target(graph, ref)
+    if not target:
+        return False
+    nid, key = target
+    graph[nid]["inputs"][key] = text
+    return True
+
+
+def prepare(workflow, new_seed=None, randomize=False, positive_prompt=None):
+    """Return (patched_graph_copy, info_dict). Never mutates the input."""
+    graph = copy.deepcopy(workflow)
+    info = {"seed": None, "prompt_set": None}
+    if randomize:
+        info["seed"] = randomize_seed(graph)
+    elif new_seed is not None:
+        info["seed"] = set_seed(graph, int(new_seed))
+    if positive_prompt is not None:
+        info["prompt_set"] = set_positive_prompt(graph, positive_prompt)
+    return graph, info

--- a/prompt_browser/requirements.txt
+++ b/prompt_browser/requirements.txt
@@ -1,0 +1,5 @@
+streamlit>=1.30
+psycopg2-binary>=2.9
+requests>=2.31
+websocket-client>=1.7
+python-dotenv>=1.0

--- a/prompt_browser/schema.sql
+++ b/prompt_browser/schema.sql
@@ -1,0 +1,49 @@
+-- prompt_browser schema (PostgreSQL)
+-- Run automatically by build_db.py, or manually: psql "$DATABASE_URL" -f schema.sql
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;   -- fast ILIKE '%term%' prompt search
+
+CREATE TABLE IF NOT EXISTS generations (
+    id              BIGSERIAL PRIMARY KEY,
+    file_path       TEXT UNIQUE NOT NULL,   -- natural key; re-import upserts
+    folder          TEXT,
+    filename        TEXT,
+    model_family    TEXT,
+    model_file      TEXT,
+    gen_type        TEXT,                   -- t2i / i2i / I2V / T2V
+    image_type      TEXT,                   -- SFW / NSFW
+    positive_prompt TEXT,
+    negative_prompt TEXT,
+    width           INTEGER,
+    height          INTEGER,
+    steps           INTEGER,
+    sampler         TEXT,
+    scheduler       TEXT,
+    guidance        REAL,
+    seed            NUMERIC(20,0),          -- ComfyUI seeds can exceed BIGINT
+    denoise         REAL,
+    lora_count      INTEGER,
+    workflow        JSONB,                  -- raw ComfyUI API graph for replay
+    created_at      TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_gen_model_family ON generations (model_family);
+CREATE INDEX IF NOT EXISTS idx_gen_image_type   ON generations (image_type);
+CREATE INDEX IF NOT EXISTS idx_gen_gen_type     ON generations (gen_type);
+CREATE INDEX IF NOT EXISTS idx_gen_pos_trgm     ON generations USING gin (positive_prompt gin_trgm_ops);
+
+-- Loras normalized so name<->strength stays tied and is queryable.
+CREATE TABLE IF NOT EXISTS loras (
+    id   SERIAL PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS generation_loras (
+    id            BIGSERIAL PRIMARY KEY,
+    generation_id BIGINT  NOT NULL REFERENCES generations(id) ON DELETE CASCADE,
+    lora_id       INTEGER NOT NULL REFERENCES loras(id) ON DELETE CASCADE,
+    strength      REAL
+);
+
+CREATE INDEX IF NOT EXISTS idx_genloras_gen  ON generation_loras (generation_id);
+CREATE INDEX IF NOT EXISTS idx_genloras_lora ON generation_loras (lora_id);


### PR DESCRIPTION
## Summary
- **prompt_browser/**: PostgreSQL + Streamlit app to browse extracted prompts and re-submit the stored ComfyUI workflow to generate (schema, JSONL importer with upsert, ComfyUI API client, seed/prompt graph patching, Streamlit UI).
- **extract_render_metadata.py**: add `--jsonl` output that includes the raw ComfyUI workflow graph per image (the DB import source).
- Document that the project runs in the **`render`** conda environment.

## Note
These landed only on the local branch previously; `main` did not yet contain the prompt_browser app or the `--jsonl` change. This PR brings them onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)